### PR TITLE
Smaller logo

### DIFF
--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -1,11 +1,10 @@
 extends:
   - stylelint-config-standard
   - stylelint-config-recommended-scss
-processors:
-  - stylelint-processor-ignore-front-matter
 ignoreFiles:
   - node_modules/**/*
   - vendor/**/*
+  - assets/style.scss
 plugins:
   - stylelint-scss
   - stylelint-order

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -18,7 +18,7 @@
         {% if page.show_image and page.image %}
             <img src="{{ page.image }}" alt="{{ page.title }}" class="featured">
         {% endif %}
-        <div class="post-content">
+        <div class="normal post-content">
             {{ content }}
         </div>
     </div>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -35,6 +35,7 @@ body {
 .normal {
   max-width: 65ch;
   margin: 2rem auto;
+  padding: 0 1rem;
 }
 
 section {

--- a/_sass/_home.scss
+++ b/_sass/_home.scss
@@ -14,6 +14,8 @@
     top: 50%;
     left: 50%;
 
+    height: 60%;
+
     transform: translate(-50%, -50%);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "stylelint": "^14.16.1",
         "stylelint-config-standard-scss": "^6.1.0",
         "stylelint-order": "^6.0.1",
-        "stylelint-processor-ignore-front-matter": "^1.0.4",
         "stylelint-scss": "^4.3.0"
       }
     },
@@ -3400,8 +3399,7 @@
       }
     },
     "stylelint-processor-ignore-front-matter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/stylelint-processor-ignore-front-matter/-/stylelint-processor-ignore-front-matter-1.0.4.tgz",
+      "version": "https://registry.npmjs.org/stylelint-processor-ignore-front-matter/-/stylelint-processor-ignore-front-matter-1.0.4.tgz",
       "integrity": "sha512-ku06Dope95ppFwZz3jdbhAbdAx4CcH/OO1DGWHvKfFe7imOT/EBaOp7O/TBVagxKgEzK/zQ07OufOLGYSg6fjQ==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "stylelint": "^14.16.1",
     "stylelint-config-standard-scss": "^6.1.0",
     "stylelint-order": "^6.0.1",
-    "stylelint-processor-ignore-front-matter": "^1.0.4",
     "stylelint-scss": "^4.3.0"
   }
 }


### PR DESCRIPTION
- Remove package-lock.json
- Restore stylelint autofix by removing front matter preprocessor
- Reduce logo size to 60%
- Add padding to normal text
